### PR TITLE
Add --from and --to date range options for csv export

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ Commands:
   list                List all available accounts
   get_ofx <out_path>  Fetch .ofx files for all accounts into out_path
   csv [options]       Fetch .csv files for accounts
+    -p, --path <path>        Export path. defaults to ./export
+    -f, --from <dd/mm/yyyy>  From date
+    -t, --to <dd/mm/yyyy>    To date
   config              Set up login details
 ```
 

--- a/barclayscrape.js
+++ b/barclayscrape.js
@@ -71,10 +71,10 @@ program
 
 program
   .command('csv')
-  .option('-p, --path', 'Export path')
+  .option('-p, --path <path>', 'Export path. defaults to ./export')
   .description('Fetch .csv files for accounts')
-  .option('-f, --from', 'From date DD/MM/YYYY')
-  .option('-t, --to', 'To date DD/MM/YYYY')
+  .option('-f, --from <dd/mm/yyyy>', 'From date')
+  .option('-t, --to <dd/mm/yyyy>', 'To date')
   .action(async (options) => {
     var sess;
     try {

--- a/barclayscrape.js
+++ b/barclayscrape.js
@@ -73,6 +73,8 @@ program
   .command('csv')
   .option('-p, --path', 'Export path')
   .description('Fetch .csv files for accounts')
+  .option('-f, --from', 'From date DD/MM/YYYY')
+  .option('-t, --to', 'To date DD/MM/YYYY')
   .action(async (options) => {
     var sess;
     try {
@@ -85,7 +87,7 @@ program
     try {
       const accounts = await sess.accounts();
       for (let account of accounts) {
-        const csvLines = await account.statementCSV();
+        const csvLines = await account.statementCSV(options.path, options.to);
         if (csvLines) {
           var label = exportLabel(account);
           var extraLog = '';


### PR DESCRIPTION
~Can't figure out how to get subcommand options visible in help text. See https://github.com/tj/commander.js/issues/905~

Need to use `./barclayscrape csv --help`