### PR TITLE
Fix for OTP input (now uses a randomised ID)

### DIFF
--- a/session.js
+++ b/session.js
@@ -63,7 +63,7 @@ class Session {
     await this.loginSelectMethod('otp');
     await u.wait(this.page, '#mobilePinsentryCode-input-1');
     await u.fillFields(this.page, {
-      '#lastDigits0': credentials['card_digits'],
+      'input[name="lastDigits"]': credentials['card_digits'],
       '#mobilePinsentryCode-input-1': credentials['otp'].slice(0, 4),
       '#mobilePinsentryCode-input-2': credentials['otp'].slice(4, 8),
     });


### PR DESCRIPTION
We can no longer select by ID, as it's occasionally invalid (starts with a digit). We will have to select by name instead (#53)